### PR TITLE
DICOM Anonymizer: Preserve private element VRs when modified

### DIFF
--- a/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizer.java
+++ b/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizer.java
@@ -424,6 +424,9 @@ public class DICOMAnonymizer {
 			}
 
 			else if (hasScript) {
+				int vr ;
+				if (isPrivate) vr = el.vr();
+				else vr = getVR(tag);
 				if (tag != Tags.DeIdentificationMethodCodeSeq) {
 					//The element wasn't handled globally
 					//and it isn't DeIdentificationMethodCodeSeq,
@@ -448,7 +451,7 @@ public class DICOMAnonymizer {
 							n = Integer.parseInt(nString);
 						}
 						if (n > blanks.length()) n = blanks.length();
-						try { context.putXX(tag, getVR(tag), blanks.substring(0,n)); }
+						try { context.putXX(tag, vr, blanks.substring(0,n)); }
 						catch (Exception e) {
 							String tagString = Tags.toString(tag);
 							logger.warn(tagString + " exception: " + e.toString()
@@ -460,7 +463,7 @@ public class DICOMAnonymizer {
 					else {
 						try {
 							if (value.equals("@empty()")) value = "";
-							context.putXX(tag, getVR(tag), value);
+							context.putXX(tag, vr, value);
 						}
 						catch (Exception e) {
 							String tagString = Tags.toString(tag);

--- a/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizer.java
+++ b/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizer.java
@@ -546,9 +546,14 @@ public class DICOMAnonymizer {
 	}
 
 	private static int getVR(int tag) {
-		TagDictionary.Entry entry = tagDictionary.lookup(tag);
-		try { return VRs.valueOf(entry.vr); }
-		catch (Exception ex) { return VRs.valueOf("SH"); }
+		if ((tag & 0x10000) == 0) {
+			TagDictionary.Entry entry = tagDictionary.lookup(tag);
+			try { return VRs.valueOf(entry.vr); }
+			catch (Exception ex) { return VRs.valueOf("SH"); }
+		}
+		else { //Private tags default to LO/UN
+			return VRs.valueOf( ((tag & 0xffff) < 0x100) ? "LO" : "UN" ) ;
+		}
 	}
 
 	static final char escapeChar 		= '\\';

--- a/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizerContext.java
+++ b/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizerContext.java
@@ -334,7 +334,7 @@ public class DICOMAnonymizerContext {
 		}
 		else if ((tag & 0x10000) != 0) {
 			if ((tag & 0xffff) < 0x100) outDS.putLO(tag,value);
-			else outDS.putUN(tag,value.getBytes("UTF-8"));
+			else outDS.putXX(tag,vr,value);
 		}
 		else {
 			//Do this in such a way that we handle multivalued elements.


### PR DESCRIPTION
When using the CTP DICOM Anonymizer, the VR of unmodified input private elements is preserved in the output DICOM, but the VR of modified private elements is always modified to UN in the output. This patch is intended to preserve the input VR of private elements that are rewritten by the DICOM Anonymizer.
