### PR TITLE
Fix acceptDuplicates=no of DirectoryStorageService

### DIFF
--- a/source/java/org/rsna/ctp/stdstages/DirectoryStorageService.java
+++ b/source/java/org/rsna/ctp/stdstages/DirectoryStorageService.java
@@ -222,6 +222,9 @@ public class DirectoryStorageService extends AbstractPipelineStage implements St
 				return null;
 			}
 			else {
+				if (savedFile.exists())
+					savedFile.delete();
+				
 				if (fileObject.copyTo(tempFile) && tempFile.renameTo(savedFile)) {
 					//The object was successfully saved, count it.
 					storedCount++;


### PR DESCRIPTION
Configuration acceptDuplicates=no of DirectoryStorageService creates
.partial duplicates. If the destination file of renameTo() exists, the
behaviour is undefined (On Windows renameTo() fails).

Due to this acceptDuplicates=no is broken (at least on Windows), because DirectoryStorageService will create duplicates (savedFile and tempFile). 
