### PR TITLE
Add Java 6 backwards compatibility

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -47,6 +47,8 @@
 
 	<target name="compile" depends="init">
 		<javac destdir="${build}" optimize="on"
+				source="1.6"
+				target="1.6"
 				classpathref="classpath"
 				includeantruntime="false"
 				debug="true" debuglevel="lines,vars,source">


### PR DESCRIPTION
Add "Source" and "Target" lines in the <javac> directory of the ant
build.xml file to allow running CTP on earlier editions of Java.