### PR TITLE
Added opportunity to use DICOM tag values as prefix in @hashuid

### DIFF
--- a/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizer.java
+++ b/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMAnonymizer.java
@@ -1110,7 +1110,15 @@ public class DICOMAnonymizer {
 		String removeUID = "@remove()";
 		try {
 			if (fn.args.length < 2) return fn.getArgs();
-			String prefix = getParam(fn);
+			
+			//use prefix of anonymizer parameter, or from dicom tag
+			String prefix = "";
+			if(fn.args[0].startsWith("@")) {
+				prefix = getParam(fn);
+			} else {
+				prefix = fn.context.contentsNull(fn.args[0], fn.thisTag);
+			}
+			
 			String uid = fn.context.contentsNull(fn.args[1], fn.thisTag);
 			//If there is no UID in the dataset, then return @remove().
 			if (uid == null) return removeUID;


### PR DESCRIPTION
Dear John,

I've got a suggestion for the anonymizer in CTP. Maybe good to first explain our use case.
Based on the patient ID, we want to determine the root UID of a data set. Therefore, we've created an extra anonymizer which adds a private dicom tag using the @lookup function.
Afterwards, a second anonymizer will perform the regular anonymization, using the value of this private dicom tag to hash the UIDs (using @hashuid(PrivateUidTag, this)).

In this change, I've extended the functionality for the first input parameter (prefix) of @hashuid. Although it's not perfect, it worked in our situation. I'm sending this pull request as you might be interested to implement some similar functionality.

Kind regards,
Johan van Soest
MAASTRO Clinic, Maastricht, The Netherlands