### PR TITLE
Add Private Halcyon RT Plan SOP Class

### DIFF
--- a/source/java/org/rsna/ctp/stdstages/dicom/PCTable.java
+++ b/source/java/org/rsna/ctp/stdstages/dicom/PCTable.java
@@ -263,7 +263,9 @@ public class PCTable extends Hashtable<String,LinkedList<String>> {
 	};
 
 	//SOP Classes not in the dcm4che UID dictionary
-	static PC[] ext_pcs = { };
+	static PC[] ext_pcs = {
+			new PC("1.2.246.352.70.1.70","$ts-native", true)
+	};
 	
 	static class SkipTable extends HashSet<String> {
 		public SkipTable() {


### PR DESCRIPTION
The Varian Halcyon is using a specific SOP Class for the RT Plans (https://visionrt.com/wp-content/uploads/2024/06/1016-0570-DICOM-Conformance-Statement-1.1.pdf). Right now - this specific DICOM series ends up in the DicomExportService quarantine. 

This code change adds the SOP Class UID in order that the specific Dicom Series will pass the CTP pipeline. 

The dcm4che project does not have it in the dictionary yet. I'm not sure if I should add an item to the source/resources/dictionary.xml. If yes, please tell me and I will do that.