### PR TITLE
Fix spurious SequenceDelimitationItem in DICOMDecompressor output

### DIFF
--- a/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMDecompressor.java
+++ b/source/java/org/rsna/ctp/stdstages/anonymizer/dicom/DICOMDecompressor.java
@@ -287,15 +287,15 @@ public class DICOMDecompressor {
 			//Now do any elements after the pixels one at a time.
 			//This is done to allow streaming of large raw data elements
 			//that occur above Tags.PixelData.
-			while (!parser.hasSeenEOF() 
-//					&& (parser.getStreamPosition() < fileLength) 
-					&& parser.getReadTag() != -1) {
-				dataset.writeHeader(
-					out,
-					encoding,
-					parser.getReadTag(),
-					parser.getReadVR(),
-					parser.getReadLength());
+			int tag;
+			while (!parser.hasSeenEOF()
+//					&& (parser.getStreamPosition() < fileLength)
+						&& ((tag=parser.getReadTag()) != -1)
+							&& ((tag >>> 16) != 0xFFFE)
+							&& (tag != 0xFFFAFFFA)
+							&& (tag != 0xFFFCFFFC)) {
+				logger.debug("About to write post-pixels element "+Integer.toHexString(tag));
+				dataset.writeHeader(out, encoding, parser.getReadTag(), parser.getReadVR(), parser.getReadLength());
 				writeValueTo(parser, buffer, out, swap);
 				parser.parseHeader();
 			}


### PR DESCRIPTION
as noted at https://groups.google.com/g/rsnas-ctpmirc-user-group/c/DtQ8vzkBzCw

## Problem

For encapsulated transfer syntaxes like JPEG 2000 `DICOMDecompressor.decompress()` writes a spurious SequenceDelimitationItem `(fffe,e0dd)` after pixel data when pixel data is the last element, creating an invalid DICOM file.

## Root Cause

Commit [2ae3e71](https://github.com/johnperry/CTP/commit/2ae3e71) commented out the `fileLength` guard in the post-pixel-data loop across five files. That was fine in the other four since their loop structures naturally advance past stale tags. But DICOMDecompressor is different, after skipping encapsulated pixel data fragments, the parser's last-read tag is still the SeqDelimitationItem. When pixel data is the last element, `hasSeenEOF()` is false and `getReadTag()` returns that stale tag (not -1), so the loop writes it to the output.

## Fix

I restructured the post-pixel-data loop to match the pattern in the other four files and added a guard against DICOM delimiter tags:

- `(tag >>> 16) != 0xFFFE` — rejects stale delimiter tags (Item, ItemDelimitationItem, SeqDelimitationItem) that should never be written as standalone elements
- `tag != 0xFFFAFFFA` / `tag != 0xFFFCFFFC` — filters Digital Signatures Sequence and Data Set Trailing Padding, matching the other files

After this change the output was valid DICOM.